### PR TITLE
Remove duplicate default declaration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,2 @@
 site_uses_backup: "{{ item.value.backup is defined and item.value.backup.enabled | default(false) }}"
-site_purge_backup: "{{ item.value.backup is defined and item.value.backup.purge | default(false) }}"
 site_purge_backup: "{{ item.value.backup is defined and item.value.backup.enabled and item.value.backup.auto and item.value.backup.purge | default(false) }}"


### PR DESCRIPTION
This causes a warning when provisioning, and the last default seems more correct.