### PR TITLE
Add support for s3 buckets with v4 signatures (fixes #3).

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ sudo duply website_name_database restore
 sudo duply website_name_uploads restore
 ```
 
+## S3 Support
+
+There is a known issue when uploading to S3 buckets that only accept V4
+signatures. In order to successfully upload, you'll need to add a little bit to
+your `wordpress_sites.yml`'s `backup:` key:
+
+```
+wordpress_sites:
+  example.com:
+    <b>backup:</b>
+      <b># ... </b>
+      <b>params:</b>
+        <b>- 'export S3_USE_SIGV4="True"'</b>
+```
+
 ## License
 
 MIT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
         target: "{{ item.value.backup.target }}/uploads"
         target_user: "{{ site_env.backup_target_user }}"
         target_pass: "{{ site_env.backup_target_pass }}"
+        params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
     # Backup database
@@ -38,6 +39,7 @@
         target: "{{ item.value.backup.target }}/database"
         target_user: "{{ site_env.backup_target_user }}"
         target_pass: "{{ site_env.backup_target_pass }}"
+        params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
   when: site_uses_backup


### PR DESCRIPTION
From #3:

> I've been trying to get my backups to work for quite a while and I finally figured it out.
>
> The reason it wasn't working is because I'm using ca-central-1 for my region, which only accepts Signature Version 4 for authentication. Duply (and boto) were not happy about this, and I kept getting NoSuchBucket errors.
>
> I did find a solution. This is documented here (basically add export S3_USE_SIGV4="True" to the config file) and I can confirm that this solution works, but only when added to the duply conf file. The problem is we don't really have a way to pass additional confirmation to duply.
>
> The backup role has a way to add configuration to the conf file. Maybe we can piggy-back off of that?

This PR piggy-backs off that and solves this issue.