### PR TITLE
Use the admin user instead of logging in as root

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: List backup jobs
   set_fact:
-    backup_user: root
+    backup_user: "{{ admin_user }}"
+    backup_group: sudo
 
     backup_mysql_user: ""
     backup_mysql_pass: ""


### PR DESCRIPTION
Trellis defaults to creating an "admin_user" to avoid logging in as root. For users who have taken that advice and locked down their root accounts, using root here might be an issue, so this plugin should default to using the admin_user instead.