### PR TITLE
Use existing database user and password for backups

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,8 @@
   set_fact:
     backup_user: root
 
-    backup_mysql_user: ""
-    backup_mysql_pass: ""
+    backup_mysql_user: "{{ site_env.db_user }}"
+    backup_mysql_pass: "{{ site_env.db_password }}"
 
     # Define the backup jobs
     backup_profiles:


### PR DESCRIPTION
Trellis handily provides us with an existing database user and password that we can borrow for running backups, which avoids either needing to use root (or mysql root) or needing to create a new database user.