### PR TITLE
Update source value for backup database

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     # Backup database
       - name: "{{ item.key }}_database"
         schedule: "{{ item.value.backup.schedule | default(omit) }}"
-        source: "mysql://{{ item.key | underscore }}_{{ env }}"          # Backup prefixes: postgresql://, maysql://, mongo://
+        source: "mysql://{{ item.value.env.db_name if(item.value.env.db_name is defined) else (item.key + '_'+ env) }}"          # Backup prefixes: postgresql://, maysql://, mongo://
         target: "{{ item.value.backup.target }}/database"
         target_user: "{{ site_env.backup_target_user }}"
         target_pass: "{{ site_env.backup_target_pass }}"


### PR DESCRIPTION
Hi,

According to the documentation of trellis, the database name can be overload.
So I've  add a condition to determine the value of source for database backup.

Please, feel free to comment, update this pull request


https://roots.io/trellis/docs/wordpress-sites/