### PR TITLE
Ability to change max_age and max_full_backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ wordpress_sites:
       <b>schedule: '0 4 * * *' # cron time of backups (change this value)</b>
       <b>purge: false # switch to true to enable automatic purging of old backups</b>
       <b>max_age: 1M # time frame for old backups to keep, Used for the "purge" command.</b>
-      <b>max_fullbkp_age: 1M # forces a full backup if last full backup reaches this age.</b>
+      <b>full_max_age: 1M # forces a full backup if last full backup reaches this age.</b>
 </pre>
 
 You can set `enabled: true` and `auto: false` to install duply profiles

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ wordpress_sites:
       <b>target: scp://user@example.com/example.com_backups # any location supported by duplicity</b>
       <b>schedule: '0 4 * * *' # cron time of backups (change this value)</b>
       <b>purge: false # switch to true to enable automatic purging of old backups</b>
+      <b>max_age: 1M # time frame for old backups to keep, Used for the "purge" command.</b>
+      <b>max_fullbkp_age: 1M # forces a full backup if last full backup reaches this age.</b>
 </pre>
 
 You can set `enabled: true` and `auto: false` to install duply profiles

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
         target: "{{ item.value.backup.target }}/uploads"
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
-        max_age: "{{ item.value.backup.max_age | default(1M) }}"
+        max_age: "{{ item.value.backup.max_age | default('1M') }}"
         max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,8 @@
         target: "{{ item.value.backup.target }}/uploads"
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
+        max_age: "{{ item.value.backup.max_age | default(1M) }}"
+        max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
@@ -25,6 +27,8 @@
         target: "{{ item.value.backup.target }}/database"
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
+        max_age: "{{ item.value.backup.max_age | default(1M) }}"
+        max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
         target: "{{ item.value.backup.target }}/database"
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
-        max_age: "{{ item.value.backup.max_age | default(1M) }}"
+        max_age: "{{ item.value.backup.max_age | default('1M') }}"
         max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_fullbkp_age: "{{ item.value.backup.max_fullbkp_age | default('1M') }}"
+        full_max_age: "{{ item.value.backup.full_max_age | default('1M') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
@@ -28,7 +28,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_fullbkp_age: "{{ item.value.backup.max_fullbkp_age | default('1M') }}"
+        full_max_age: "{{ item.value.backup.full_max_age | default('1M') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
+        max_full_backups: "{{ item.value.backup.max_full_backups | default('1') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
@@ -28,7 +28,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_full_backups: "{{ item.value.backup.max_full_backups | default(1) }}"
+        max_full_backups: "{{ item.value.backup.max_full_backups | default('1') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_full_backups: "{{ item.value.backup.max_full_backups | default('1') }}"
+        max_fullbkp_age: "{{ item.value.backup.max_fullbkp_age | default('1M') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 
@@ -28,7 +28,7 @@
         target_user: "{{ site_env.backup_target_user | default(false) }}"
         target_pass: "{{ site_env.backup_target_pass | default(false) }}"
         max_age: "{{ item.value.backup.max_age | default('1M') }}"
-        max_full_backups: "{{ item.value.backup.max_full_backups | default('1') }}"
+        max_fullbkp_age: "{{ item.value.backup.max_fullbkp_age | default('1M') }}"
         params: "{{ item.value.backup.params | default([]) }}"
         action: "{{ site_purge_backup | ternary('purge_backup --force', 'backup') }}"
 


### PR DESCRIPTION
I added the variables to your tasks main.yml file. 

This is untested as I am not sure how to test these without creating a new galaxy role. 

I want different sites to have different ages and amounts of backups. This seemed like the best way to make that happen.

Please let me know if I should do this differently.