### PR TITLE
Roots renamed requirements.yml to galaxy.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It does not backup website code. If you need to restore, you must first deploy y
 
 ## Get Started
 
-Add the role and its dependencies to the `requirements.yml` file of Trellis :
+Add the role and its dependencies to the `galaxy.yml` file of Trellis :
 
 ```yaml
 - name: backup


### PR DESCRIPTION
See https://github.com/roots/trellis/commit/846041dac3c400041e8492d4fffea85dde3b53a3 .
(Whitespace at the end was auto-added by Github)