### PR TITLE
Add db_user and db_password defaults to tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,8 @@
   set_fact:
     backup_user: root
 
-    backup_mysql_user: ""
-    backup_mysql_pass: ""
+    backup_mysql_user: "{{ site_env.db_user | default('') }}"
+    backup_mysql_pass: "{{ site_env.db_password | default('') }}"
     backup_mysql_host: "{{ site_env.db_host | default('') }}"
 
     # Define the backup jobs


### PR DESCRIPTION
The `backup_mysql_user` and the `backup_mysql_pass` are empty by default. They are always set in the vault file used by Trellis, (since WP needs it to connect to the database) so it's easier to use those when they are already set.