### PR TITLE
Add compatibility with Ansible > 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add the role and its dependencies to the `galaxy.yml` file of Trellis :
 ```yaml
 - name: backup
   src: xilonz.trellis_backup
-  version: 2.1.7
+  version: 2.2.0
 ```
 
 Run `ansible-galaxy install -r galaxy.yml` to install the new roles.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It does not backup website code. If you need to restore, you must first deploy y
 Add the role and its dependencies to the `galaxy.yml` file of Trellis :
 
 ```yaml
-- name: backup
-  src: xilonz.trellis_backup
+- name: trellis-backup
+  src: https://github.com/E-VANCE/trellis-backup-role
   version: 2.2.0
 ```
 
@@ -29,7 +29,7 @@ Then, add the roles to the `server.yml` :
 ```yaml
 roles:
   ... other Trellis roles ...
-  - { role: backup, tags: [backup] }
+  - { role: trellis-backup, tags: [backup] }
 ```
 
 ## Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@
     author: Arjan Steenbergen
     description: Install automated backups on Trellis using duply
     license: "MIT"
-    min_ansible_version: 2.2
+    min_ansible_version: 2.11
     platforms:
     - name: Ubuntu
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,4 +18,7 @@
     - duply
     - wordpress
   dependencies:
-  - lafranceinsoumise.backup
+  # Pin dependency to a commit that uses include_tasks instead of deprecated include
+  - name: lafranceinsoumise.backup
+    src: https://github.com/lafranceinsoumise/ansible-backup
+    version: e13bf363d5705e70d4b22c432c053c1368ecfa16

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,11 +38,24 @@
         post_actions: "{{ item.value.backup.post_actions | default([]) }}"
 
   when: site_uses_backup
-  with_dict: "{{ wordpress_sites }}"
+  loop: "{{ wordpress_sites | default({}) | dict2items }}"
   register: backup_jobs
 
 - name: Configure backup jobs
-  set_fact: backup_profiles="{{ backup_jobs.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.backup_profiles.0') | list }} + {{ backup_jobs.results | selectattr('ansible_facts', 'defined') | map(attribute='ansible_facts.backup_profiles.1') | list }}"
+  when: site_uses_backup
+  set_fact:
+    backup_profiles: >-
+      {{
+        (backup_jobs.results
+          | selectattr('ansible_facts', 'defined')
+          | map(attribute='ansible_facts.backup_profiles.0')
+          | list)
+        +
+        (backup_jobs.results
+          | selectattr('ansible_facts', 'defined')
+          | map(attribute='ansible_facts.backup_profiles.1')
+          | list)
+      }}
 
 - name: Run backup role
   include_role:


### PR DESCRIPTION
This PR adds compatibility with Ansible > 2.11 which includes using a newer version of the `lafranceinsoumise.backup`-dependency as well as a fix for the new loop-variable syntax (see #42).